### PR TITLE
fix: set web3 version to latest stable

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -9,7 +9,7 @@
     </head>
     <body data-sveltekit-preload-data="hover">
         <!-- This step is necessary for now because the Web3.js library doesn't play well with bundlers (Vite, Rollup, Webpack, Snowpack, etc), thus we cannot simply add a dependency in package.json. -->
-        <script src="https://cdn.jsdelivr.net/npm/web3@latest/dist/web3.min.js"></script>
+        <script src="https://cdn.jsdelivr.net/gh/ethereum/web3.js@1.3.4/dist/web3.min.js"></script>
         <!--  -->
         <div style="display: contents">%sveltekit.body%</div>
     </body>


### PR DESCRIPTION
Looks like this is a dependency issue. The dependency we have in this project for svelte web3 needs to add web3 using a CDN which was pointing to `latest`. Suprise surprise, some days ago web3 released a major version moving from 1.x.y to 4.x.y :trollface: 
This PR aims to set the web3 version to the latest known stable version, checked in `web.archive.org`. 
Please note that, as of now, the native tokens never resolve, it seems like the IF is doing some maintainance work in the EVM, for if that happens, you can comment out `pollNativeTokens` for testing purposes

⚠️ This is just a temporary solution, until the dependencies we use fix their problems with the new version of web3. Would be nice opening an issue to https://github.com/clbrge/svelte-web3 explaining the situation.

Close https://github.com/boxfish-studio/evm-toolkit/issues/7